### PR TITLE
Fix bug

### DIFF
--- a/mit_d3m/dataset.py
+++ b/mit_d3m/dataset.py
@@ -59,7 +59,10 @@ class D3MDataset:
             self.dsHome = os.path.dirname(dataset)
             _dsDoc = dataset
 
-        assert os.path.exists(_dsDoc), _dsDoc
+        if not os.path.exists(_dsDoc):
+            logger.critical('Error: Expected to find datasetDoc.json at path %s', _dsDoc)
+            raise FileNotFoundError
+
         with open(_dsDoc, 'r') as f:
             self.dsDoc = json.load(f)
 
@@ -213,7 +216,9 @@ class D3MProblem:
 
             # read the schema in prHome
             _prDoc = os.path.join(self.prHome, 'problemDoc.json')
-            assert os.path.exists(_prDoc), _prDoc
+            if not os.path.exists(_prDoc):
+                logger.critical('Error: Expected to find problemDoc.json at path %s', _prDoc)
+                raise FileNotFoundError
             with open(_prDoc, 'r') as f:
                 self.prDoc = json.load(f)
 

--- a/tests/test_mit_d3m.py
+++ b/tests/test_mit_d3m.py
@@ -43,9 +43,10 @@ class MitD3mTest(TestCase):
         download_dataset(bucket, key, filename)
         mock_download_file.assert_called_with(Bucket=bucket, Key=key, Filename=filename)
 
+    @patch('os.path.exists')
     @patch('tarfile.open')
-    @patch('shutil.rmtree')
-    def test_extract_dataset(self, mock_rmtree, mock_open):
+    def test_extract_dataset(self, mock_open, mock_exists):
+        mock_exists.return_value = True
         mock_extractall = mock_open.return_value.__enter__.return_value.extractall
         src = '/foo/bar/things.tar.gz'
         dst = '/foo/bar/things'


### PR DESCRIPTION
Fixes two "bugs":
- tarfiles were being mistakenly downloaded to `/path/to/root/dataset_identifier/dataset_identifier.tar.gz` instead of `/path/to/root/dataset_identifier.tar.gz`
- tarfiles are now extracted to `/path/to/root/dataset_identifier`, which results in paths like `/path/to/root/dataset_identifier/dataset_identifier/TRAIN/data.csv`. Notice that dataset_identifier appears twice in the path, which is not a mistake. Since the tarfiles locate files underneath the `dataset_identifier` subdirectory, it is safer to just place them within `/path/to/root/dataset_identifier` than to extract them to the data root. This results in a compatibility issue with previous versions, which will now no longer be able to load existing extracted datasets.