### PR TITLE
Preallocate array for ImageLoader.load_resources

### DIFF
--- a/mit_d3m/loaders.py
+++ b/mit_d3m/loaders.py
@@ -451,7 +451,7 @@ class ImageLoader(ResourceLoader):
 
             filename = os.path.join(image_dir, filename)
             image = load_img(filename)
-            image = image.resize(self.INPUT_SHAPE)
+            image = image.resize(self.INPUT_SHAPE[:2])
             image = img_to_array(image)
             image = image / 255.0  # Quantize images.
             images[i, :, :, :] = image

--- a/mit_d3m/loaders.py
+++ b/mit_d3m/loaders.py
@@ -434,7 +434,7 @@ class ResourceLoader(Loader):
 
 class ImageLoader(ResourceLoader):
 
-    INPUT_SHAPE = [224, 224, 3]
+    INPUT_SHAPE = (224, 224, 3)
     EPOCHS = 1
 
     def load_resources(self, X, resource_column, d3mds):
@@ -443,21 +443,20 @@ class ImageLoader(ResourceLoader):
         LOGGER.info("Loading %s images", len(X))
 
         image_dir = d3mds.get_resources_dir('image')
-        images = []
+        images = np.empty((len(X), *self.INPUT_SHAPE), dtype=np.float32)
 
-        for filename in X[resource_column]:
+        for i, filename in enumerate(X[resource_column]):
             if used_memory() > available_memory():
                 raise MemoryError()
 
             filename = os.path.join(image_dir, filename)
             image = load_img(filename)
-            image = image.resize(tuple(self.INPUT_SHAPE[0:2]))
+            image = image.resize(self.INPUT_SHAPE)
             image = img_to_array(image)
             image = image / 255.0  # Quantize images.
-            images.append(image)
+            images[i,:,:,:] = image
 
-        return np.array(images)
-
+        return images
 
 class TextLoader(ResourceLoader):
 

--- a/mit_d3m/loaders.py
+++ b/mit_d3m/loaders.py
@@ -458,7 +458,7 @@ class ImageLoader(ResourceLoader):
 
         return images
 
-    
+
 class TextLoader(ResourceLoader):
 
     def load_resources(self, X, resource_column, d3mds):

--- a/mit_d3m/loaders.py
+++ b/mit_d3m/loaders.py
@@ -454,10 +454,11 @@ class ImageLoader(ResourceLoader):
             image = image.resize(self.INPUT_SHAPE)
             image = img_to_array(image)
             image = image / 255.0  # Quantize images.
-            images[i,:,:,:] = image
+            images[i, :, :, :] = image
 
         return images
 
+    
 class TextLoader(ResourceLoader):
 
     def load_resources(self, X, resource_column, d3mds):

--- a/setup.py
+++ b/setup.py
@@ -34,31 +34,31 @@ tests_require = [
 
 development_requires = [
     # general
-    'bumpversion>=0.5.3',
-    'pip>=10.0.0',
-    'watchdog>=0.8.3',
+    'bumpversion>=0.5.3,<0.6',
+    'pip>=9.0.1',
+    'watchdog>=0.8.3,<0.11',
 
     # docs
-    'm2r>=0.2.0',
-    'Sphinx>=1.7.1',
-    'sphinx_rtd_theme>=0.2.4',
+    'm2r>=0.2.0,<0.3',
+    'Sphinx>=1.7.1,<3',
+    'sphinx_rtd_theme>=0.2.4,<0.5',
     'autodocsumm>=0.1.10',
 
     # style check
-    'flake8>=3.5.0',
-    'isort>=4.3.4',
+    'flake8>=3.7.7,<4',
+    'isort>=4.3.4,<5',
 
     # fix style issues
-    'autoflake>=1.1',
-    'autopep8>=1.3.5',
+    'autoflake>=1.1,<2',
+    'autopep8>=1.4.3,<2',
 
     # distribute on PyPI
-    'twine>=1.10.0',
+    'twine>=1.10.0,<4',
     'wheel>=0.30.0',
 
     # Advanced testing
-    'tox>=2.9.1',
-    'coverage>=4.5.1',
+    'coverage>=4.5.1,<6',
+    'tox>=2.9.1,<4',
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ install_requires = [
     'psutil>=5.4.8',
     'pymongo>=3.7.2',
     'scikit-learn>=0.20.0',
-    'python-dateutil>=2.1,<2.8.1'    # botocore requirement
+    'python-dateutil>=2.1,<2.8.1',    # botocore requirement
+    'docutils<0.16,>=0.10',    # botocore requirement
 ]
 
 setup_requires = [


### PR DESCRIPTION
ImageLoader.load_resources returns an np array, so loading all images into a list and then making an np array out of them actually requires np to copy all of the images into a new continguous block of memory, effectively doubling memory requirements. Since the number of images is known ahead of time, it is much more efficient to preallocate the array and then write into it.