### PR TITLE
Use keras_preprocessing dependency

### DIFF
--- a/mit_d3m/loaders.py
+++ b/mit_d3m/loaders.py
@@ -438,7 +438,7 @@ class ImageLoader(ResourceLoader):
     EPOCHS = 1
 
     def load_resources(self, X, resource_column, d3mds):
-        from keras.preprocessing.image import img_to_array, load_img  # noqa
+        from keras_preprocessing.image import img_to_array, load_img  # noqa
 
         LOGGER.info("Loading %s images", len(X))
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('HISTORY.md') as history_file:
 install_requires = [
     'boto3>=1.9.27',
     'funcy>=1.11',
-    'keras-preprocessing>=1.1.2',
+    'keras-preprocessing[image]>=1.1.2',
     'networkx>=2.1',
     'numpy>=1.15.2',
     'pandas>=0.23.4',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('HISTORY.md') as history_file:
 install_requires = [
     'boto3>=1.9.27',
     'funcy>=1.11',
-    'keras>=2.2.4',
+    'keras-preprocessing>=1.1.2',
     'networkx>=2.1',
     'numpy>=1.15.2',
     'pandas>=0.23.4',


### PR DESCRIPTION
From keras, we only use keras.preprocessing.image, which is actually packaged separately. Installs keras_preprocessing accordingly. The image extra is needed for the load_img functionality to work.

See https://github.com/keras-team/keras-preprocessing/blob/master/setup.py for details on [image] extra

Resolves #20 